### PR TITLE
Add local test harness and Pascal Script runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Build outputs
+/runner/bin/
+*.o
+*.ppu
+*.rsj
+
+# Vendored dependencies
+/runner/vendor/pascalscript/
+
+# Pascal/Lazarus tooling
+*.lps
+*.lpi
+*.lpr
+*.dcu
+*.dsk
+*.dproj.local
+
+# Node
+/node_modules/

--- a/New_Zealand_Annex_A_scoring_2020_inputs.md
+++ b/New_Zealand_Annex_A_scoring_2020_inputs.md
@@ -1,0 +1,42 @@
+﻿# New Zealand Annex A scoring 2020.pas — Input Variables
+
+This list includes only variables that are *not initialized in the script* and are therefore supplied by the hosting system (SeeYou). Descriptions come from `skills/seeyou-scoring-scripts/references/seeyou_data_model.md`. Anything not described there is marked **undocumented**.
+
+## General units
+- Times: seconds since midnight.
+- Distances: meters.
+- Speeds: meters per second.
+
+## Top-level inputs
+| Variable | Description |
+| --- | --- |
+| `DayTag` | undocumented |
+| `Task` | SeeYou task object (fields listed below) |
+| `Pilots[]` | Array of pilot objects (fields listed below) |
+
+## Outputs (for clarity)
+| Variable | Description |
+| --- | --- |
+| `Info1` | output text shown to user |
+| `Info2` | output text shown to user |
+| `Info3` | output text shown to user |
+
+## Task fields used
+| Variable | Description |
+| --- | --- |
+| `Task.TaskTime` | task time for AAT |
+| `Task.NoStartBeforeTime` | start opening time |
+| `Task.ClassID` | class id enum |
+
+## Pilot fields used (from `Pilots[i]`)
+| Variable | Description |
+| --- | --- |
+| `Hcap` | handicap (1.0 if no handicaps) |
+| `isHC` | boolean flag for hors concours |
+| `dis` | calculated flight distance |
+| `takeoff` | takeoff time |
+| `start` | calculated flight start time |
+| `finish` | calculated flight finish time |
+| `speed` | calculated flight speed |
+| `sfinish` | value shown on score sheets |
+| `Penalty` | point penalty |

--- a/README.md
+++ b/README.md
@@ -25,3 +25,33 @@ When setting up the contest on SoaringSpot, Rename the existing SoaringSpot Cont
 'unknown'   =   'Open Unhandicapped'    //  Unofficial Class (unhandicapped)   
 'double_seater'  = '2 Seater'           //  Unofficial Class (uncandicapped)   
 
+## Local Test Harness (FreePascal + Node.js)
+
+This repo now includes a local scoring test harness to run the Pascal Script against fixture data.
+
+### What was added
+- `testbed/run.js`: Node.js harness that feeds JSON fixtures into a runner and diffs outputs.
+- `testbed/fixtures/nz_annex_a_invented.json`: Invented fixture data matching the script inputs.
+- `runner/src/seeyou_runner.pas`: FreePascal runner scaffold (JSON in/out).
+- `runner/build_runner.bat`: Build script for the runner.
+- `skills/`: Local Codex skills and references used to document the SeeYou data model and test schema.
+
+### How to use
+1. Install FreePascal and make sure `fpc` is on PATH.
+2. Fetch Pascal Script sources (gitignored in this repo):
+   ```powershell
+   git clone https://github.com/remobjects/pascalscript runner\vendor\pascalscript
+   ```
+   If you hit a type conversion error in `uPSCompiler.pas`, replace `TempDouble := tbtDouble(p^.textended);` with `TempDouble := p^.textended;`.
+3. Build the runner:
+   ```powershell
+   runner\build_runner.bat
+   ```
+4. Run the harness from the repo root:
+   ```powershell
+   node testbed\run.js testbed\fixtures\nz_annex_a_invented.json --runner runner\bin\seeyou_runner.exe --script "New Zealand Annex A scoring 2020.pas"
+   ```
+
+### Current limitations
+- The runner now executes the Pascal Script engine.
+- `expected.points` in fixtures is currently empty. Fill these in to get pass/fail diffs.

--- a/runner/build_runner.bat
+++ b/runner/build_runner.bat
@@ -1,0 +1,12 @@
+@echo off
+REM Build script for FreePascal (fpc must be on PATH)
+REM Outputs runner\bin\seeyou_runner.exe relative to this script
+
+setlocal
+set SCRIPT_DIR=%~dp0
+set OUTDIR=%SCRIPT_DIR%bin
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+
+set PSSRC=%SCRIPT_DIR%vendor\pascalscript\Source
+fpc -Mobjfpc -O2 -Fu"%PSSRC%" -FE"%OUTDIR%" "%SCRIPT_DIR%src\seeyou_runner.pas"
+endlocal

--- a/runner/src/seeyou_runner.pas
+++ b/runner/src/seeyou_runner.pas
@@ -1,0 +1,610 @@
+﻿program seeyou_runner;
+
+{$mode objfpc}{$H+}
+
+// SeeYou Pascal Script runner (FreePascal + Pascal Script)
+// JSON in via stdin, JSON out via stdout.
+
+uses
+  SysUtils, Classes, fpjson, jsonparser,
+  uPSCompiler, uPSRuntime, uPSUtils;
+
+type
+
+  TPilot = record
+    CompID: string;
+    isHC: boolean;
+    Hcap: double;
+    Penalty: double;
+    takeoff: double;
+    start: double;
+    finish: double;
+    dis: double;
+    speed: double;
+    sfinish: double;
+    // outputs
+    Points: integer;
+    sstart: double;
+    sdis: double;
+    sspeed: double;
+    Warning: string;
+    td1: double; // temp
+  end;
+
+  TTask = record
+    TotalDis: double;
+    TaskTime: double;
+    NoStartBeforeTime: LongInt;
+    ClassID: string;
+  end;
+
+const
+  TASK_TOTALDIS = 0;
+  TASK_TASKTIME = 1;
+  TASK_NOSTARTBEFORE = 2;
+  TASK_CLASSID = 3;
+
+  PILOT_COMPID = 0;
+  PILOT_ISHC = 1;
+  PILOT_HCAP = 2;
+  PILOT_PENALTY = 3;
+  PILOT_TAKEOFF = 4;
+  PILOT_START = 5;
+  PILOT_FINISH = 6;
+  PILOT_DIS = 7;
+  PILOT_SPEED = 8;
+  PILOT_SFINISH = 9;
+  PILOT_POINTS = 10;
+  PILOT_SSTART = 11;
+  PILOT_SDIS = 12;
+  PILOT_SSPEED = 13;
+  PILOT_WARNING = 14;
+  PILOT_TD1 = 15;
+
+var
+  Task: TTask;
+  Pilots: array of TPilot;
+  DayTag: string;
+  Info1, Info2, Info3: string;
+  GUsesRegistered: boolean;
+  GLastScriptText: string;
+
+function ReadAllStdin: string;
+var
+  S: TStringList;
+  Line: string;
+begin
+  S := TStringList.Create;
+  try
+    while not EOF(Input) do
+    begin
+      ReadLn(Input, Line);
+      S.Add(Line);
+    end;
+    Result := S.Text;
+  finally
+    S.Free;
+  end;
+end;
+
+procedure LoadInputJson(const JsonText: string);
+var
+  Root: TJSONObject;
+  Arr: TJSONArray;
+  I: integer;
+  P: TJSONObject;
+  TaskObj: TJSONObject;
+begin
+  Root := GetJSON(JsonText) as TJSONObject;
+  try
+    DayTag := Root.Get('day_tag', '');
+    TaskObj := Root.Objects['task'];
+    Task.TotalDis := TaskObj.Get('total_dis_m', 0.0);
+    Task.TaskTime := TaskObj.Get('task_time_s', 0.0);
+    Task.NoStartBeforeTime := TaskObj.Get('no_start_before_s', 0);
+    Task.ClassID := Root.Get('class_id', 'unknown');
+
+    Arr := Root.Arrays['pilots'];
+    SetLength(Pilots, Arr.Count);
+    for I := 0 to Arr.Count - 1 do
+    begin
+      P := Arr.Objects[I];
+      Pilots[I].CompID := P.Get('comp_id', '');
+      Pilots[I].isHC := P.Get('is_hc', false);
+      Pilots[I].Hcap := P.Get('hcap', 1.0);
+      Pilots[I].Penalty := P.Get('penalty', 0.0);
+      Pilots[I].takeoff := P.Get('takeoff_s', -1.0);
+      Pilots[I].start := P.Get('start_s', 0.0);
+      Pilots[I].finish := P.Get('finish_s', 0.0);
+      Pilots[I].dis := P.Get('dis_m', 0.0);
+      Pilots[I].speed := P.Get('speed_ms', 0.0);
+      Pilots[I].sfinish := P.Get('sfinish_s', 0.0);
+    end;
+  finally
+    Root.Free;
+  end;
+end;
+
+function BuildOutputJson: string;
+var
+  Root: TJSONObject;
+  Arr: TJSONArray;
+  P: TJSONObject;
+  I: integer;
+begin
+  Root := TJSONObject.Create;
+  try
+    Root.Add('info1', Info1);
+    Root.Add('info2', Info2);
+    Root.Add('info3', Info3);
+
+    Arr := TJSONArray.Create;
+    for I := 0 to High(Pilots) do
+    begin
+      P := TJSONObject.Create;
+      P.Add('comp_id', Pilots[I].CompID);
+      P.Add('points', Pilots[I].Points);
+      P.Add('sstart_s', Pilots[I].sstart);
+      P.Add('sfinish_s', Pilots[I].sfinish);
+      P.Add('sdis_m', Pilots[I].sdis);
+      P.Add('sspeed_ms', Pilots[I].sspeed);
+      P.Add('warning', Pilots[I].Warning);
+      Arr.Add(P);
+    end;
+    Root.Add('pilots', Arr);
+
+    Result := Root.AsJSON;
+  finally
+    Root.Free;
+  end;
+end;
+
+function FixStrToIntTwoArg(const S: string): string;
+const
+  Name = 'StrToInt';
+var
+  i, j, depth, nameLen: integer;
+  hasComma: boolean;
+begin
+  Result := '';
+  nameLen := Length(Name);
+  i := 1;
+  while i <= Length(S) do
+  begin
+    if (i + nameLen <= Length(S)) and (Copy(S, i, nameLen) = Name) and
+       (i + nameLen <= Length(S)) and (S[i + nameLen] = '(') then
+    begin
+      j := i + nameLen;
+      depth := 0;
+      hasComma := false;
+      while j <= Length(S) do
+      begin
+        if S[j] = '(' then
+          Inc(depth)
+        else if S[j] = ')' then
+        begin
+          Dec(depth);
+          if depth = 0 then
+          begin
+            Inc(j);
+            break;
+          end;
+        end
+        else if (S[j] = ',') and (depth = 1) then
+          hasComma := true;
+        Inc(j);
+      end;
+
+      if hasComma then
+        Result := Result + 'StrToIntDef' + Copy(S, i + nameLen, j - (i + nameLen))
+      else
+        Result := Result + Name + Copy(S, i + nameLen, j - (i + nameLen));
+      i := j;
+    end
+    else
+    begin
+      Result := Result + S[i];
+      Inc(i);
+    end;
+  end;
+end;
+
+procedure RegisterTypes(Comp: TPSPascalCompiler);
+var
+  Rec: TPSRecordType;
+  Arr: TPSArrayType;
+  TDouble, TString, TBool, TInt: TPSType;
+begin
+  TDouble := Comp.FindType('Double');
+  TString := Comp.FindType('string');
+  TBool := Comp.FindType('Boolean');
+  TInt := Comp.FindType('LongInt');
+
+  Rec := TPSRecordType(Comp.AddType('TTask', btRecord));
+  with Rec.AddRecVal do begin FieldOrgName := 'TotalDis'; aType := TDouble; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'TaskTime'; aType := TDouble; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'NoStartBeforeTime'; aType := TInt; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'ClassID'; aType := TString; end;
+
+  Rec := TPSRecordType(Comp.AddType('TPilot', btRecord));
+  with Rec.AddRecVal do begin FieldOrgName := 'CompID'; aType := TString; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'isHC'; aType := TBool; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'Hcap'; aType := TDouble; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'Penalty'; aType := TDouble; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'takeoff'; aType := TDouble; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'start'; aType := TDouble; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'finish'; aType := TDouble; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'dis'; aType := TDouble; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'speed'; aType := TDouble; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'sfinish'; aType := TDouble; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'Points'; aType := TInt; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'sstart'; aType := TDouble; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'sdis'; aType := TDouble; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'sspeed'; aType := TDouble; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'Warning'; aType := TString; end;
+  with Rec.AddRecVal do begin FieldOrgName := 'td1'; aType := TDouble; end;
+
+  Arr := TPSArrayType(Comp.AddType('TPilotArray', btArray));
+  Arr.ArrayTypeNo := Comp.FindType('TPilot');
+end;
+
+procedure RegisterVariables(Comp: TPSPascalCompiler);
+begin
+  Comp.AddUsedVariableN('DayTag', 'string');
+  Comp.AddUsedVariableN('Task', 'TTask');
+  Comp.AddUsedVariableN('Pilots', 'TPilotArray');
+  Comp.AddUsedVariableN('Info1', 'string');
+  Comp.AddUsedVariableN('Info2', 'string');
+  Comp.AddUsedVariableN('Info3', 'string');
+end;
+
+function BuildCompileError(Comp: TPSPascalCompiler): string;
+var
+  I: integer;
+  Err: TPSPascalCompilerError;
+  Line: string;
+  LineText: string;
+  Lines: TStringList;
+begin
+  Result := '';
+  Lines := TStringList.Create;
+  try
+    Lines.Text := GLastScriptText;
+    if (Lines.Count > 0) and (Lines[Lines.Count-1] = '') then
+      Lines.Delete(Lines.Count-1);
+  except
+    Lines.Clear;
+  end;
+  for I := 0 to Comp.MsgCount - 1 do
+  begin
+    if Comp.Msg[I] is TPSPascalCompilerError then
+    begin
+      Err := TPSPascalCompilerError(Comp.Msg[I]);
+      if (Err.Row > 0) and (Err.Row <= Lines.Count) then
+        LineText := Lines[Err.Row-1]
+      else
+        LineText := '';
+      Line := Format('(%d,%d) %s %s', [Err.Row, Err.Col, string(Err.ShortMessageToString), LineText]);
+      Result := Result + Line + LineEnding;
+    end;
+  end;
+  if Result = '' then
+    Result := 'Unknown compile error';
+  Lines.Free;
+end;
+
+function FixFunctionResultAssignments(const S: string): string;
+var
+  Names: TStringList;
+  Lines: TStringList;
+  I, J: integer;
+  Line, Trimmed, Name: string;
+  function ReplaceFuncAssign(const Text, FuncName: string): string;
+  var
+    i, nlen, j: integer;
+    chPrev: char;
+  begin
+    Result := '';
+    nlen := Length(FuncName);
+    i := 1;
+    while i <= Length(Text) do
+    begin
+      if (i + nlen - 1 <= Length(Text)) and
+         (AnsiCompareText(Copy(Text, i, nlen), FuncName) = 0) then
+      begin
+        chPrev := #0;
+        if i > 1 then chPrev := Text[i-1];
+        if (i = 1) or not (chPrev in ['A'..'Z','a'..'z','0'..'9','_']) then
+        begin
+          j := i + nlen;
+          if (j > Length(Text)) or not (Text[j] in ['A'..'Z','a'..'z','0'..'9','_']) then
+          begin
+            while (j <= Length(Text)) and (Text[j] in [' ', #9]) do
+              Inc(j);
+            if (j <= Length(Text) - 1) and (Text[j] = ':') and (Text[j+1] = '=') then
+            begin
+              Result := Result + 'Result';
+              Result := Result + Copy(Text, i + nlen, j - (i + nlen));
+              Result := Result + ':=';
+              i := j + 2;
+              Continue;
+            end;
+          end;
+        end;
+      end;
+      Result := Result + Text[i];
+      Inc(i);
+    end;
+  end;
+begin
+  Names := TStringList.Create;
+  Lines := TStringList.Create;
+  try
+    Lines.Text := S;
+    for I := 0 to Lines.Count - 1 do
+    begin
+      Line := Lines[I];
+      Trimmed := TrimLeft(Line);
+      if (Length(Trimmed) >= 8) and (AnsiCompareText(Copy(Trimmed, 1, 8), 'function') = 0) then
+      begin
+        J := 9;
+        while (J <= Length(Trimmed)) and (Trimmed[J] = ' ') do Inc(J);
+        Name := '';
+        while (J <= Length(Trimmed)) and (Trimmed[J] in ['A'..'Z','a'..'z','0'..'9','_']) do
+        begin
+          Name := Name + Trimmed[J];
+          Inc(J);
+        end;
+        if Name <> '' then
+          Names.Add(Name);
+      end;
+    end;
+    Result := S;
+    for I := 0 to Names.Count - 1 do
+      Result := ReplaceFuncAssign(Result, Names[I]);
+  finally
+    Names.Free;
+    Lines.Free;
+  end;
+end;
+
+function FixEndSemicolons(const S: string): string;
+var
+  Lines: TStringList;
+  I, J: integer;
+  Line, Trimmed, NextTrimmed: string;
+begin
+  Lines := TStringList.Create;
+  try
+    Lines.Text := S;
+    for I := 0 to Lines.Count - 1 do
+    begin
+      Line := Lines[I];
+      Trimmed := Trim(Line);
+      if (AnsiCompareText(Trimmed, 'end') = 0) then
+      begin
+        J := I + 1;
+        NextTrimmed := '';
+        while (J < Lines.Count) and (NextTrimmed = '') do
+        begin
+          NextTrimmed := Trim(Lines[J]);
+          Inc(J);
+        end;
+        if (NextTrimmed <> '') and (AnsiCompareText(Copy(NextTrimmed, 1, 4), 'else') = 0) then
+          Continue;
+        Lines[I] := Line + ';';
+      end;
+    end;
+    Result := Lines.Text;
+  finally
+    Lines.Free;
+  end;
+end;
+
+function OnUsesHandler(Sender: TPSPascalCompiler; const Name: tbtString): Boolean;
+begin
+  if not GUsesRegistered then
+  begin
+    RegisterTypes(Sender);
+    RegisterVariables(Sender);
+    Sender.AddDelphiFunction('function FormatFloat(const Format: string; Value: Extended): string;');
+    GUsesRegistered := true;
+  end;
+  Result := true;
+end;
+
+function CompileScript(const ScriptPath: string; out Compiled: tbtString; out Error: string): boolean;
+var
+  Comp: TPSPascalCompiler;
+  ScriptText: string;
+  Script: TStringList;
+begin
+  Result := false;
+  Error := '';
+  Comp := TPSPascalCompiler.Create;
+  Script := TStringList.Create;
+  try
+    GUsesRegistered := false;
+    Comp.OnUses := @OnUsesHandler;
+
+    Script.LoadFromFile(ScriptPath);
+    ScriptText := FixStrToIntTwoArg(Script.Text);
+    ScriptText := FixFunctionResultAssignments(ScriptText);
+    ScriptText := FixEndSemicolons(ScriptText);
+    GLastScriptText := ScriptText;
+
+    if not Comp.Compile(ScriptText) then
+    begin
+      Error := BuildCompileError(Comp);
+      Exit;
+    end;
+
+    if not Comp.GetOutput(Compiled) then
+    begin
+      Error := 'Failed to get compiled output';
+      Exit;
+    end;
+
+    Result := true;
+  finally
+    Script.Free;
+    Comp.Free;
+  end;
+end;
+
+function RecField(const Rec: TPSVariantIFC; FieldNo: integer): TPSVariantIFC;
+var
+  Offs: Cardinal;
+  RType: TPSTypeRec_Record;
+begin
+  Result := Rec;
+  if (Result.aType = nil) or (Result.aType.BaseType <> btRecord) then
+  begin
+    Result.aType := nil;
+    Result.Dta := nil;
+    exit;
+  end;
+  RType := TPSTypeRec_Record(Result.aType);
+  if (FieldNo < 0) or (FieldNo >= RType.FieldTypes.Count) then
+  begin
+    Result.aType := nil;
+    Result.Dta := nil;
+    exit;
+  end;
+  Offs := Cardinal(RType.RealFieldOffsets[FieldNo]);
+  Result.Dta := Pointer(PtrUInt(Result.Dta) + Offs);
+  Result.aType := TPSTypeRec(RType.FieldTypes[FieldNo]);
+end;
+
+procedure SetTaskRecord(const Rec: TPSVariantIFC; const T: TTask);
+begin
+  VNSetReal(RecField(Rec, TASK_TOTALDIS), T.TotalDis);
+  VNSetReal(RecField(Rec, TASK_TASKTIME), T.TaskTime);
+  VNSetInt(RecField(Rec, TASK_NOSTARTBEFORE), T.NoStartBeforeTime);
+  VNSetString(RecField(Rec, TASK_CLASSID), T.ClassID);
+end;
+
+procedure SetPilotRecord(const Rec: TPSVariantIFC; const P: TPilot);
+begin
+  VNSetString(RecField(Rec, PILOT_COMPID), P.CompID);
+  VNSetInt(RecField(Rec, PILOT_ISHC), Ord(P.isHC));
+  VNSetReal(RecField(Rec, PILOT_HCAP), P.Hcap);
+  VNSetReal(RecField(Rec, PILOT_PENALTY), P.Penalty);
+  VNSetReal(RecField(Rec, PILOT_TAKEOFF), P.takeoff);
+  VNSetReal(RecField(Rec, PILOT_START), P.start);
+  VNSetReal(RecField(Rec, PILOT_FINISH), P.finish);
+  VNSetReal(RecField(Rec, PILOT_DIS), P.dis);
+  VNSetReal(RecField(Rec, PILOT_SPEED), P.speed);
+  VNSetReal(RecField(Rec, PILOT_SFINISH), P.sfinish);
+  VNSetInt(RecField(Rec, PILOT_POINTS), P.Points);
+  VNSetReal(RecField(Rec, PILOT_SSTART), P.sstart);
+  VNSetReal(RecField(Rec, PILOT_SDIS), P.sdis);
+  VNSetReal(RecField(Rec, PILOT_SSPEED), P.sspeed);
+  VNSetString(RecField(Rec, PILOT_WARNING), P.Warning);
+  VNSetReal(RecField(Rec, PILOT_TD1), P.td1);
+end;
+
+procedure GetPilotRecord(const Rec: TPSVariantIFC; var P: TPilot);
+begin
+  P.Points := VNGetInt(RecField(Rec, PILOT_POINTS));
+  P.sstart := VNGetReal(RecField(Rec, PILOT_SSTART));
+  P.sfinish := VNGetReal(RecField(Rec, PILOT_SFINISH));
+  P.sdis := VNGetReal(RecField(Rec, PILOT_SDIS));
+  P.sspeed := VNGetReal(RecField(Rec, PILOT_SSPEED));
+  P.Warning := VNGetString(RecField(Rec, PILOT_WARNING));
+end;
+
+procedure ExecuteScript(const ScriptPath: string);
+var
+  Compiled: tbtString;
+  Err: string;
+  Exec: TPSExec;
+  V: PIFVariant;
+  ArrIfc, RecIfc: TPSVariantIFC;
+  I: integer;
+begin
+  if not CompileScript(ScriptPath, Compiled, Err) then
+    raise Exception.Create('Compile error: ' + Err);
+
+  Exec := TPSExec.Create;
+  try
+    Exec.RegisterDelphiFunction(@FormatFloat, 'FormatFloat', cdRegister);
+
+    if not Exec.LoadData(Compiled) then
+      raise Exception.Create('Failed to load compiled script');
+
+    V := Exec.GetVar2('DayTag');
+    if V <> nil then
+      VSetString(V, DayTag);
+
+    V := Exec.GetVar2('Task');
+    if V <> nil then
+    begin
+      RecIfc := NewTPSVariantIFC(V, true);
+      SetTaskRecord(RecIfc, Task);
+    end;
+
+    V := Exec.GetVar2('Pilots');
+    if V <> nil then
+    begin
+      SetPSArrayLength(V, Length(Pilots));
+      ArrIfc := NewTPSVariantIFC(V, true);
+      for I := 0 to High(Pilots) do
+      begin
+        RecIfc := PSGetArrayField(ArrIfc, I);
+        SetPilotRecord(RecIfc, Pilots[I]);
+      end;
+    end;
+
+    if not Exec.RunScript then
+      raise Exception.Create('Script error: ' + string(Exec.ExceptionString));
+
+    V := Exec.GetVar2('Info1');
+    if V <> nil then Info1 := VGetString(V);
+    V := Exec.GetVar2('Info2');
+    if V <> nil then Info2 := VGetString(V);
+    V := Exec.GetVar2('Info3');
+    if V <> nil then Info3 := VGetString(V);
+
+    V := Exec.GetVar2('Pilots');
+    if V <> nil then
+    begin
+      ArrIfc := NewTPSVariantIFC(V, false);
+      for I := 0 to High(Pilots) do
+      begin
+        RecIfc := PSGetArrayField(ArrIfc, I);
+        GetPilotRecord(RecIfc, Pilots[I]);
+      end;
+    end;
+  finally
+    Exec.Free;
+  end;
+end;
+
+var
+  InputText: string;
+  ScriptPath: string;
+  Root: TJSONObject;
+
+begin
+  try
+    InputText := ReadAllStdin;
+    LoadInputJson(InputText);
+
+    Root := GetJSON(InputText) as TJSONObject;
+    try
+      ScriptPath := Root.Get('script_path', '');
+    finally
+      Root.Free;
+    end;
+
+    ExecuteScript(ScriptPath);
+    WriteLn(BuildOutputJson);
+  except
+    on E: Exception do
+    begin
+      WriteLn(StdErr, E.Message);
+      Halt(1);
+    end;
+  end;
+end.

--- a/skills/seeyou-score-testbed/SKILL.md
+++ b/skills/seeyou-score-testbed/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: seeyou-score-testbed
+description: Design and build a local test harness that simulates SeeYou scoring scripts using structured test cases (Task, Pilots, DayTag, class IDs) and expected outputs. Use when creating, running, or expanding tests for SeeYou competition scoring.
+---
+
+# SeeYou Score Testbed
+
+## Overview
+Use this skill to plan and implement a repeatable test rig for SeeYou Pascal Script scoring. The goal is to run a script against fixture data and compare points and info outputs to expected results. The default approach is a Node.js harness that calls a small Pascal Script runner process via JSON I/O.
+
+## Workflow
+1. Define the test case schema (see `references/testcase_schema.md`) and keep it versioned.
+2. Populate fixtures from real contest days or synthetic edge cases; include expected `Points` per pilot and expected `Info1..Info3` if relevant.
+3. Use the default execution strategy unless instructed otherwise:
+   - Node.js harness + Pascal Script runner executable (Delphi/FPC) called via `child_process`.
+   - Runner reads JSON input and emits JSON output (see `references/runner_contract.md`).
+4. Implement the adapter that maps the schema into the script's global structures (`Task`, `Pilots`, etc.).
+5. Run the harness and compare outputs; report diffs with pilot IDs and field names.
+
+## Fixture Design Notes
+- Include at least one case per class and per task type (AAT vs racing).
+- Include edge cases: zero launches, invalid day thresholds, no finishers, buffer-zone starts.
+- Store units explicitly in the fixture schema (meters, seconds, m/s).
+
+## References
+- Data model and field definitions: `references/seeyou_data_model.md`.
+- Test case schema: `references/testcase_schema.md`.
+- Runner I/O contract: `references/runner_contract.md`.

--- a/skills/seeyou-score-testbed/agents/openai.yaml
+++ b/skills/seeyou-score-testbed/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SeeYou Score Testbed"
+  short_description: "Design a test harness for SeeYou scripts"
+  default_prompt: "Use $seeyou-score-testbed to design a test harness for a SeeYou scoring script."

--- a/skills/seeyou-score-testbed/references/runner_contract.md
+++ b/skills/seeyou-score-testbed/references/runner_contract.md
@@ -1,0 +1,44 @@
+# Pascal Script runner contract (JSON)
+
+## Input
+Top-level fields:
+- `script_path`: string, path to the Pascal Script file.
+- `day_tag`: string, passed to script as DayTag.
+- `class_id`: string, SeeYou `ClassID`.
+- `task`: object (see below).
+- `pilots`: array of pilot objects (see below).
+- `options`: object (optional):
+  - `use_handicaps`: 0|1|2 (mirrors script constant if you want override support).
+
+### task
+- `total_dis_m`: number
+- `task_time_s`: number (0 for racing task)
+- `no_start_before_s`: number
+- `points`: optional array of task points with `lon`, `lat`, `d_m`, `crs_deg`
+
+### pilots[]
+- `comp_id`: string
+- `is_hc`: boolean
+- `hcap`: number
+- `penalty`: number
+- `takeoff_s`: number
+- `start_s`: number
+- `finish_s`: number
+- `dis_m`: number
+- `speed_ms`: number
+- `sfinish_s`: number (nonzero marks finisher in many scripts)
+
+## Output
+Top-level fields:
+- `info1`: string
+- `info2`: string
+- `info3`: string
+- `pilots`: array with at least:
+  - `comp_id`: string
+  - `points`: integer
+  - `sstart_s`, `sfinish_s`, `sdis_m`, `sspeed_ms`: numbers (score sheet fields)
+  - `warning`: string (if set by script)
+
+## Notes
+- Units: meters, seconds, m/s.
+- Keep runner deterministic; no file I/O beyond the script itself.

--- a/skills/seeyou-score-testbed/references/seeyou_data_model.md
+++ b/skills/seeyou-score-testbed/references/seeyou_data_model.md
@@ -1,0 +1,68 @@
+# SeeYou data model summary
+
+Source: SeeYou competition scripts README.
+
+## General notes
+- Unless noted, numeric fields are doubles.
+- Time fields are in seconds since midnight.
+
+## TPilots fields (daily script)
+- `sstart`, `sfinish`, `sdis`, `sspeed`: values shown on score sheets.
+- `Points`: final points for the day.
+- `PointString`: points as string.
+- `Hcap`: handicap (1.0 if no handicaps).
+- `Penalty`: point penalty.
+- `start`, `finish`, `dis`, `speed`: calculated flight values.
+- `tstart`, `tfinish`, `tdis`, `tspeed`: task adjusted values.
+- `takeoff`, `landing`, `phototime`: takeoff/landing/photo times.
+- `isHC`: boolean flag for hors concours.
+- `FinishAlt`, `DisToGoal`: finish altitude and distance to goal.
+- `Tag`: pilot tag string.
+- `Leg[]`, `LegT[]`: arrays of `TLeg` for actual and task legs.
+- `Warning`: warning string for pilot.
+- `CompID`: competitor id string.
+- `PilotTag`: second tag string.
+- `user_str1`, `user_str2`, `user_str3`: user strings.
+- `td1`, `td2`, `td3`: temporary doubles.
+- `Markers[]`: array of `TMarker`.
+- `PotStarts[]`: array of potential starts (integers).
+
+## TPilots fields (total script)
+- `Total`: total points.
+- `TotalString`: total points string.
+- `DayPts[]`: array of per-day points.
+- `DayPtsString[]`: array of per-day points strings.
+
+## Task fields
+- `TotalDis`: total task distance.
+- `TaskTime`: task time for AAT.
+- `NoStartBeforeTime`: start opening time.
+- `Point[]`: array of `TTaskPoint`.
+- `ClassID`: class id enum.
+- `ClassName`: class name string.
+
+## ClassID enum values
+- `unknown`, `club`, `standard`, `15_meter`, `open`, `18_meter`, `double_seater`, `13_5_meter`.
+
+## TTaskPoint fields
+- `lon`, `lat`: coordinates.
+- `d`, `crs`: distance and course to previous point.
+- `td1`, `td2`, `td3`: temp doubles.
+
+## TFix fields
+- `Tsec`: time (integer).
+- `AltQnh`, `AltQne`: altitudes.
+- `Gsp`: ground speed.
+- `DoT`, `Cur`, `Vol`, `Enl`, `Mop`: sensor fields.
+- `EngineOn`: boolean engine state.
+
+## TLeg fields
+- `start`, `finish`: leg start/finish times.
+- `d`, `crs`: leg distance and course.
+
+## TMarker fields
+- `Tsec`: time.
+- `Msg`: message.
+- `info1`, `info2`: strings.
+- `DatTag`: data tag.
+- `ShowMessage`: boolean.

--- a/skills/seeyou-score-testbed/references/testcase_schema.md
+++ b/skills/seeyou-score-testbed/references/testcase_schema.md
@@ -1,0 +1,41 @@
+# SeeYou scoring test case schema (suggested)
+
+This schema is a minimal, practical subset for daily scoring scripts.
+
+## Top-level
+- `id`: string
+- `description`: string
+- `class_id`: SeeYou `ClassID`
+- `day_tag`: string (contents of DayTag)
+- `task`: object
+- `pilots`: array of pilot objects
+- `expected`: object with expected outputs
+
+## task
+- `total_dis_m`: number
+- `task_time_s`: number (0 for racing task)
+- `no_start_before_s`: number
+- `points`: optional array of task points with `lon`, `lat`, `d_m`, `crs_deg`
+
+## pilots[] (minimum subset)
+- `comp_id`: string
+- `is_hc`: boolean
+- `hcap`: number
+- `penalty`: number
+- `takeoff_s`: number
+- `start_s`: number
+- `finish_s`: number
+- `dis_m`: number
+- `speed_ms`: number
+- `sfinish_s`: number (nonzero marks finisher in many scripts)
+
+## expected
+- `points`: map of `comp_id` to expected integer points
+- `info1`: optional string
+- `info2`: optional string
+- `info3`: optional string
+
+## Units
+- Distances: meters
+- Times: seconds since midnight
+- Speeds: meters per second

--- a/skills/seeyou-scoring-scripts/SKILL.md
+++ b/skills/seeyou-scoring-scripts/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: seeyou-scoring-scripts
+description: Analyze, explain, and modify SeeYou competition scoring scripts written in Pascal Script, including daily or total scoring, class rule customizations, and use of the SeeYou data model (Task, Pilots, DayTag, etc.). Use when working with scoring formulas, rule tweaks, or debugging SeeYou script output.
+---
+
+# SeeYou Scoring Scripts
+
+## Overview
+Use this skill to understand and edit SeeYou scoring scripts (Pascal Script). Focus on mapping formulas to the SeeYou data model and keeping units and validity rules consistent.
+
+## Workflow
+1. Identify script type (day vs total) and locate the main scoring loop and outputs (Points, Info1..Info3).
+2. Load the data model reference in `references/seeyou_data_model.md` and map each field used in the script to the SeeYou structures.
+3. Trace the scoring pipeline:
+   - Validation checks and early exits.
+   - Class-specific parameters (min distance, 1000-point distance, handicaps).
+   - Day factors (max distance/time, completion ratios).
+   - Provisional score calculation and any normalization or compression.
+   - Final points and penalties.
+4. Verify units: distances in meters, times in seconds, speeds in m/s unless explicitly converted.
+5. Ensure no divide-by-zero or invalid array access; preserve existing guard clauses.
+
+## Editing Guidelines
+- Keep outputs limited to fields SeeYou expects (e.g., `Pilots[i].Points`, `Info1..Info3`).
+- If adding tags or parameters, parse them defensively (missing or malformed values should not crash).
+- When changing class logic, update both minimum distance and 1000-point distance rules consistently.
+- Preserve handicapping behavior unless the rule change explicitly requires altering it.
+
+## Common Pitfalls
+- Changing `UseHandicaps` without handling `Auto_Hcaps_on`.
+- Using `Task.TaskTime` when the task is not AAT.
+- Treating `Pilots[i].start` and `finish` as valid without checking for > 0 (or >= 0 where intended).
+
+## References
+- Data model and field definitions: `references/seeyou_data_model.md`.

--- a/skills/seeyou-scoring-scripts/agents/openai.yaml
+++ b/skills/seeyou-scoring-scripts/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SeeYou Scoring Scripts"
+  short_description: "Analyze and edit SeeYou Pascal scripts"
+  default_prompt: "Use $seeyou-scoring-scripts to analyze or modify a SeeYou competition scoring script."

--- a/skills/seeyou-scoring-scripts/references/seeyou_data_model.md
+++ b/skills/seeyou-scoring-scripts/references/seeyou_data_model.md
@@ -1,0 +1,68 @@
+# SeeYou data model summary
+
+Source: SeeYou competition scripts README.
+
+## General notes
+- Unless noted, numeric fields are doubles.
+- Time fields are in seconds since midnight.
+
+## TPilots fields (daily script)
+- `sstart`, `sfinish`, `sdis`, `sspeed`: values shown on score sheets.
+- `Points`: final points for the day.
+- `PointString`: points as string.
+- `Hcap`: handicap (1.0 if no handicaps).
+- `Penalty`: point penalty.
+- `start`, `finish`, `dis`, `speed`: calculated flight values.
+- `tstart`, `tfinish`, `tdis`, `tspeed`: task adjusted values.
+- `takeoff`, `landing`, `phototime`: takeoff/landing/photo times.
+- `isHC`: boolean flag for hors concours.
+- `FinishAlt`, `DisToGoal`: finish altitude and distance to goal.
+- `Tag`: pilot tag string.
+- `Leg[]`, `LegT[]`: arrays of `TLeg` for actual and task legs.
+- `Warning`: warning string for pilot.
+- `CompID`: competitor id string.
+- `PilotTag`: second tag string.
+- `user_str1`, `user_str2`, `user_str3`: user strings.
+- `td1`, `td2`, `td3`: temporary doubles.
+- `Markers[]`: array of `TMarker`.
+- `PotStarts[]`: array of potential starts (integers).
+
+## TPilots fields (total script)
+- `Total`: total points.
+- `TotalString`: total points string.
+- `DayPts[]`: array of per-day points.
+- `DayPtsString[]`: array of per-day points strings.
+
+## Task fields
+- `TotalDis`: total task distance.
+- `TaskTime`: task time for AAT.
+- `NoStartBeforeTime`: start opening time.
+- `Point[]`: array of `TTaskPoint`.
+- `ClassID`: class id enum.
+- `ClassName`: class name string.
+
+## ClassID enum values
+- `unknown`, `club`, `standard`, `15_meter`, `open`, `18_meter`, `double_seater`, `13_5_meter`.
+
+## TTaskPoint fields
+- `lon`, `lat`: coordinates.
+- `d`, `crs`: distance and course to previous point.
+- `td1`, `td2`, `td3`: temp doubles.
+
+## TFix fields
+- `Tsec`: time (integer).
+- `AltQnh`, `AltQne`: altitudes.
+- `Gsp`: ground speed.
+- `DoT`, `Cur`, `Vol`, `Enl`, `Mop`: sensor fields.
+- `EngineOn`: boolean engine state.
+
+## TLeg fields
+- `start`, `finish`: leg start/finish times.
+- `d`, `crs`: leg distance and course.
+
+## TMarker fields
+- `Tsec`: time.
+- `Msg`: message.
+- `info1`, `info2`: strings.
+- `DatTag`: data tag.
+- `ShowMessage`: boolean.

--- a/testbed/fixtures/nz_annex_a_invented.json
+++ b/testbed/fixtures/nz_annex_a_invented.json
@@ -1,0 +1,147 @@
+﻿[
+  {
+    "id": "nz-annex-a-open-racing-001",
+    "description": "Invented open-class racing task with start intervals; includes finisher, non-finisher, HC pilot, and non-launch.",
+    "class_id": "open",
+    "day_tag": "Interval=10;NumIntervals=7",
+    "task": {
+      "total_dis_m": 200000,
+      "task_time_s": 0,
+      "no_start_before_s": 46800,
+      "points": [
+        { "lon": 175.67, "lat": -37.81, "d_m": 0, "crs_deg": 0 },
+        { "lon": 175.90, "lat": -37.95, "d_m": 85000, "crs_deg": 210 },
+        { "lon": 176.10, "lat": -38.05, "d_m": 115000, "crs_deg": 195 }
+      ]
+    },
+    "pilots": [
+      {
+        "comp_id": "A1",
+        "is_hc": false,
+        "hcap": 1.00,
+        "penalty": 0,
+        "takeoff_s": 45000,
+        "start_s": 47100,
+        "finish_s": 51300,
+        "dis_m": 200000,
+        "speed_ms": 47.619,
+        "sfinish_s": 51300
+      },
+      {
+        "comp_id": "B2",
+        "is_hc": false,
+        "hcap": 1.05,
+        "penalty": 0,
+        "takeoff_s": 45200,
+        "start_s": 47700,
+        "finish_s": 52200,
+        "dis_m": 190000,
+        "speed_ms": 42.222,
+        "sfinish_s": 52200
+      },
+      {
+        "comp_id": "C3",
+        "is_hc": false,
+        "hcap": 0.98,
+        "penalty": 50,
+        "takeoff_s": 45300,
+        "start_s": 46810,
+        "finish_s": 0,
+        "dis_m": 150000,
+        "speed_ms": 0,
+        "sfinish_s": 0
+      },
+      {
+        "comp_id": "D4",
+        "is_hc": true,
+        "hcap": 1.10,
+        "penalty": 0,
+        "takeoff_s": 45400,
+        "start_s": 48000,
+        "finish_s": 54000,
+        "dis_m": 210000,
+        "speed_ms": 35.000,
+        "sfinish_s": 54000
+      },
+      {
+        "comp_id": "E5",
+        "is_hc": false,
+        "hcap": 1.02,
+        "penalty": 0,
+        "takeoff_s": -1,
+        "start_s": 0,
+        "finish_s": 0,
+        "dis_m": 0,
+        "speed_ms": 0,
+        "sfinish_s": 0
+      }
+    ],
+    "expected": {
+      "points": {}
+    }
+  },
+  {
+    "id": "nz-annex-a-club-aat-002",
+    "description": "Invented club-class AAT with low completion ratio to trigger invalid day rule.",
+    "class_id": "club",
+    "day_tag": "",
+    "task": {
+      "total_dis_m": 220000,
+      "task_time_s": 7200,
+      "no_start_before_s": 46800
+    },
+    "pilots": [
+      {
+        "comp_id": "C1",
+        "is_hc": false,
+        "hcap": 1.03,
+        "penalty": 0,
+        "takeoff_s": 45000,
+        "start_s": 46830,
+        "finish_s": 54030,
+        "dis_m": 60000,
+        "speed_ms": 8.333,
+        "sfinish_s": 54030
+      },
+      {
+        "comp_id": "C2",
+        "is_hc": false,
+        "hcap": 0.99,
+        "penalty": 0,
+        "takeoff_s": 45100,
+        "start_s": 46860,
+        "finish_s": 0,
+        "dis_m": 30000,
+        "speed_ms": 0,
+        "sfinish_s": 0
+      },
+      {
+        "comp_id": "C3",
+        "is_hc": false,
+        "hcap": 1.05,
+        "penalty": 20,
+        "takeoff_s": 45200,
+        "start_s": 46920,
+        "finish_s": 0,
+        "dis_m": 25000,
+        "speed_ms": 0,
+        "sfinish_s": 0
+      },
+      {
+        "comp_id": "C4",
+        "is_hc": false,
+        "hcap": 1.01,
+        "penalty": 0,
+        "takeoff_s": 45300,
+        "start_s": 47000,
+        "finish_s": 0,
+        "dis_m": 20000,
+        "speed_ms": 0,
+        "sfinish_s": 0
+      }
+    ],
+    "expected": {
+      "points": {}
+    }
+  }
+]

--- a/testbed/run.js
+++ b/testbed/run.js
@@ -1,0 +1,120 @@
+﻿// testbed/run.js
+// Usage: node testbed/run.js testbed/fixtures/nz_annex_a_invented.json --runner runner/bin/seeyou_runner.exe --script "New Zealand Annex A scoring 2020.pas"
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--runner') args.runner = argv[++i];
+    else if (a === '--script') args.script = argv[++i];
+    else args._.push(a);
+  }
+  return args;
+}
+
+function loadJson(p) {
+  let text = fs.readFileSync(p, 'utf8');
+  if (text.charCodeAt(0) === 0xFEFF) {
+    text = text.slice(1);
+  }
+  return JSON.parse(text);
+}
+
+function runCase(runnerPath, scriptPath, testCase) {
+  const input = {
+    script_path: scriptPath,
+    day_tag: testCase.day_tag || '',
+    class_id: testCase.class_id,
+    task: testCase.task,
+    pilots: testCase.pilots,
+    options: testCase.options || {}
+  };
+
+  const proc = spawnSync(runnerPath, [], {
+    input: JSON.stringify(input),
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024
+  });
+
+  if (proc.error) {
+    return { ok: false, error: proc.error.message };
+  }
+  if (proc.status !== 0) {
+    return { ok: false, error: proc.stderr || `runner exit ${proc.status}` };
+  }
+
+  let output;
+  try {
+    output = JSON.parse(proc.stdout || '{}');
+  } catch (e) {
+    return { ok: false, error: `invalid JSON from runner: ${e.message}` };
+  }
+
+  return { ok: true, output };
+}
+
+function comparePoints(testCase, output) {
+  const expected = testCase.expected && testCase.expected.points ? testCase.expected.points : {};
+  const actualMap = {};
+  if (Array.isArray(output.pilots)) {
+    for (const p of output.pilots) actualMap[p.comp_id] = p.points;
+  }
+
+  const diffs = [];
+  for (const compId of Object.keys(expected)) {
+    const exp = expected[compId];
+    const act = actualMap[compId];
+    if (act === undefined) {
+      diffs.push(`${compId}: expected ${exp}, missing actual`);
+    } else if (act !== exp) {
+      diffs.push(`${compId}: expected ${exp}, got ${act}`);
+    }
+  }
+
+  return diffs;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const fixturePath = args._[0];
+  if (!fixturePath) {
+    console.error('usage: node testbed/run.js <fixtures.json> --runner <runner.exe> --script <script.pas>');
+    process.exit(2);
+  }
+
+  const runnerPath = args.runner || path.resolve('runner/bin/seeyou_runner.exe');
+  const scriptPath = args.script || path.resolve('New Zealand Annex A scoring 2020.pas');
+
+  const cases = loadJson(fixturePath);
+  if (!Array.isArray(cases)) {
+    console.error('fixtures file must be a JSON array');
+    process.exit(2);
+  }
+
+  let failures = 0;
+  for (const tc of cases) {
+    const label = tc.id || 'case';
+    const res = runCase(runnerPath, scriptPath, tc);
+    if (!res.ok) {
+      console.log(`[FAIL] ${label} - ${res.error}`);
+      failures++;
+      continue;
+    }
+    const diffs = comparePoints(tc, res.output);
+    if (diffs.length) {
+      console.log(`[FAIL] ${label}`);
+      for (const d of diffs) console.log(`  ${d}`);
+      failures++;
+    } else {
+      console.log(`[OK] ${label}`);
+    }
+  }
+
+  process.exit(failures ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
Add a local FreePascal + Node test harness to execute SeeYou scoring scripts with JSON fixtures, plus docs and input mapping.

@IvandaNothabeer 

### ACTION:   
need real data to be added in the test cases (testbed/fixtures/....json)
@ipearx can we easily export from https://www.soaringspot.com/en_gb/nz-multiclass-national-championships-jan-2026-matamata-2026/results/open/task-1-on-2026-02-01/daily for example?

### What was added
- `testbed/run.js`: Node.js harness that feeds JSON fixtures into a runner and diffs outputs.
- `testbed/fixtures/nz_annex_a_invented.json`: Invented fixture data matching the script inputs.
- `runner/src/seeyou_runner.pas`: FreePascal runner scaffold (JSON in/out).
- `runner/build_runner.bat`: Build script for the runner.
- `skills/`: Local Codex skills and references used to document the SeeYou data model and test schema.

### How to use
1. Install FreePascal and make sure `fpc` is on PATH.
2. Fetch Pascal Script sources (gitignored in this repo):
   ```powershell
   git clone https://github.com/remobjects/pascalscript runner\vendor\pascalscript
   ```
   If you hit a type conversion error in `uPSCompiler.pas`, replace `TempDouble := tbtDouble(p^.textended);` with `TempDouble := p^.textended;`.
3. Build the runner:
   ```powershell
   runner\build_runner.bat
   ```
4. Run the harness from the repo root:
   ```powershell
   node testbed\run.js testbed\fixtures\nz_annex_a_invented.json --runner runner\bin\seeyou_runner.exe --script "New Zealand Annex A scoring 2020.pas"
   ```

### Current limitations
- The runner now executes the Pascal Script engine.
- `expected.points` in fixtures is currently empty. Fill these in to get pass/fail diffs.
